### PR TITLE
background_color fixed

### DIFF
--- a/src/kivy_garden/qrcode/qrcode_widget.py
+++ b/src/kivy_garden/qrcode/qrcode_widget.py
@@ -129,7 +129,7 @@ class QRCodeWidget(FloatLayout):
         Clock.schedule_once(partial(self._create_texture, k), -1)
 
         cr, cg, cb, ca = self.background_color[:]
-        cr, cg, cb = cr*255, cg*255, cb*255
+        cr, cg, cb = int(cr*255), int(cg*255), int(cb*255)
         # used bytearray for python 3.5 eliminates need for btext
         buff = bytearray()
         for r in range(k):


### PR DESCRIPTION
Hi. When I run this code, I get that error. So, I fixed the problem. 

#### Code:
```
from kivy.app import App
from kivy.lang import Builder

kv = """
#:import QRCodeWidget kivy_garden.qrcode

BoxLayout:
    orientation: 'vertical'
    Button:
        text: 'press to change qrcode'
        on_release: qr.data = "Kivy Rocks!"
    QRCodeWidget:
        id: qr
        data: 'Hello World'
        background_color: [0.9607843137254902, 0.9607843137254902, 0.9607843137254902, 1.0]
"""

class TestApp(App):
    def build(self):
        return Builder.load_string(kv)

TestApp().run()
```

#### Error:
```
 Traceback (most recent call last):
   File "C:\Users\pc\AppData\Local\Programs\Python\Python38-32\lib\threading.py", line 932, in _bootstrap_inner
     self.run()
   File "C:\Users\pc\AppData\Local\Programs\Python\Python38-32\lib\threading.py", line 870, in run
     self._target(*self._args, **self._kwargs)
   File "C:\Users\pc\AppData\Local\Programs\Python\Python38-32\lib\site-packages\kivy_garden\qrcode\qrcode_widget.py", line 70, in generate_qr
     self.update_qr()
   File "C:\Users\pc\AppData\Local\Programs\Python\Python38-32\lib\site-packages\kivy_garden\qrcode\qrcode_widget.py", line 98, in update_qr
     self.update_texture()
   File "C:\Users\pc\AppData\Local\Programs\Python\Python38-32\lib\site-packages\kivy_garden\qrcode\qrcode_widget.py", line 127, in update_texture
     buff.extend([0, 0, 0] if matrix[r][c] else [cr, cg, cb])
 TypeError: 'float' object cannot be interpreted as an integer
```
